### PR TITLE
Enable elevation data use with standalone graph builder.

### DIFF
--- a/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
@@ -29,6 +29,7 @@ import org.opentripplanner.graph_builder.impl.StreetlessStopLinker;
 import org.opentripplanner.graph_builder.impl.TransitToStreetNetworkGraphBuilderImpl;
 import org.opentripplanner.graph_builder.impl.TransitToTaggedStopsGraphBuilderImpl;
 import org.opentripplanner.graph_builder.impl.ned.ElevationGraphBuilderImpl;
+import org.opentripplanner.graph_builder.impl.ned.GeotiffGridCoverageFactoryImpl;
 import org.opentripplanner.graph_builder.impl.ned.NEDGridCoverageFactoryImpl;
 import org.opentripplanner.graph_builder.impl.osm.DefaultWayPropertySetSource;
 import org.opentripplanner.graph_builder.impl.osm.OpenStreetMapGraphBuilderImpl;
@@ -134,6 +135,7 @@ public class OTPConfigurator {
         List<File> gtfsFiles = Lists.newArrayList();
         List<File> osmFiles =  Lists.newArrayList();
         List<File> shapeFiles = Lists.newArrayList();
+        List<File> elevationFiles = Lists.newArrayList();
         File configFile = null;
         /* For now this is adding files from all directories listed, rather than building multiple graphs. */
         for (File dir : params.build) {
@@ -157,6 +159,10 @@ public class OTPConfigurator {
                     LOG.info("Found SHAPEFILE {}", file);
                     shapeFiles.add(file);
                     break;
+                case ELEVATION:
+                    LOG.info("Found ELEVATION file {}", file);
+                    elevationFiles.add(file);
+                    break;
                 case CONFIG:
                     if (!params.noEmbedConfig) {
                         LOG.info("Found CONFIG file {}", file);
@@ -170,7 +176,8 @@ public class OTPConfigurator {
         }
         boolean hasOSM  = ! (osmFiles.isEmpty()  || params.noStreets);
         boolean hasGTFS = ! (gtfsFiles.isEmpty() || params.noTransit);
-        boolean hasShapefiles = ! (shapeFiles.isEmpty());
+        boolean hasElevation = !elevationFiles.isEmpty();
+        boolean hasShapefiles = !shapeFiles.isEmpty();
         if ( ! (hasOSM || hasGTFS )) {
             LOG.error("Found no input files from which to build a graph in {}", params.build.toString());
             return null;
@@ -183,12 +190,20 @@ public class OTPConfigurator {
             }
             OpenStreetMapGraphBuilderImpl osmBuilder = new OpenStreetMapGraphBuilderImpl(osmProviders);
             DefaultStreetEdgeFactory streetEdgeFactory = new DefaultStreetEdgeFactory();
-            streetEdgeFactory.useElevationData = params.elevation;
+            streetEdgeFactory.useElevationData = hasElevation;
             osmBuilder.edgeFactory = streetEdgeFactory;
             DefaultWayPropertySetSource defaultWayPropertySetSource = new DefaultWayPropertySetSource();
             osmBuilder.setDefaultWayPropertySetSource(defaultWayPropertySetSource);
             osmBuilder.skipVisibility = params.skipVisibility;
             graphBuilder.addGraphBuilder(osmBuilder);
+            if ( hasElevation ) {
+                if (elevationFiles.size() > 1) {
+                    LOG.warn("More than one elevation file found!  Only using first one, {}.", elevationFiles.get(0));
+                }
+                ElevationGridCoverageFactory gcf = new GeotiffGridCoverageFactoryImpl(elevationFiles.get(0));
+                GraphBuilder elevationBuilder = new ElevationGraphBuilderImpl(gcf);
+                graphBuilder.addGraphBuilder(elevationBuilder);
+            }
             graphBuilder.addGraphBuilder(new TransitToStreetNetworkGraphBuilderImpl());
             graphBuilder.addGraphBuilder(new PruneFloatingIslands());
             if (hasShapefiles) {
@@ -285,7 +300,7 @@ public class OTPConfigurator {
      * Represents the different types of input files for a graph build.
      */
     private static enum InputFileType {
-        GTFS, OSM, CONFIG, SHAPEFILE, OTHER;
+        GTFS, OSM, CONFIG, SHAPEFILE, ELEVATION, OTHER;
         public static InputFileType forFile(File file) {
             String name = file.getName();
             if (name.endsWith(".zip")) {
@@ -299,6 +314,7 @@ public class OTPConfigurator {
             if (name.endsWith(".pbf")) return OSM;
             if (name.endsWith(".osm")) return OSM;
             if (name.endsWith(".osm.xml")) return OSM;
+            if (name.endsWith(".tif")) return ELEVATION;
             if (name.endsWith(".shp")) return SHAPEFILE;
             if (name.equals("Embed.properties")) return CONFIG;
             return OTHER;


### PR DESCRIPTION
The existing `elevation` command-line argument attempts to download NED data automatically,
but the implementation for that is broken due to changes in how NED data is served.
This will automatically find GeoTIFF files in the data directory, and use the first one found
to build elevation profiles into the graph.
