### PR TITLE
Feature/just get times

### DIFF
--- a/src/main/java/org/opentripplanner/analyst/Histogram.java
+++ b/src/main/java/org/opentripplanner/analyst/Histogram.java
@@ -145,7 +145,8 @@ public class Histogram implements Serializable {
                 int totalSum = 0;
                 minute = 0;
                 for (int i = 0; i < seconds; i++) {
-                    totalSum += values[i];
+                    if (values[i] > 0)
+                        totalSum += values[i]; // ignore negative values
                     if (i % 60 == 59) {
                         sums[minute] = totalSum;
                         if (counts[minute] > 0) {

--- a/src/main/java/org/opentripplanner/analyst/PointSet.java
+++ b/src/main/java/org/opentripplanner/analyst/PointSet.java
@@ -408,11 +408,11 @@ public class PointSet implements Serializable {
         int index = 0;
         try {
             JsonParser jp = f.createParser(is);
-            JsonToken current = jp.nextToken();
+            jp.nextToken();
             // Iterate over the key:value pairs in the top-level JSON object
             while (jp.nextToken() != JsonToken.END_OBJECT) {
                 String key = jp.getCurrentName();
-                current = jp.nextToken();
+                jp.nextToken();
                 if (key.equals("properties")) {
                     JsonNode properties = jp.readValueAsTree();
 

--- a/src/main/java/org/opentripplanner/analyst/ResultSet.java
+++ b/src/main/java/org/opentripplanner/analyst/ResultSet.java
@@ -57,13 +57,8 @@ public class ResultSet implements Serializable{
     public ResultSet() {
     }
 
-    /** Build a new ResultSet by evaluating the given TimeSurface at all the given sample points, not including times. */
-    public ResultSet(SampleSet samples, TimeSurface surface){
-        this(samples, surface, false);
-    }
-    
     /** Build a new ResultSet by evaluating the given TimeSurface at all the given sample points, optionally including times. */
-    public ResultSet(SampleSet samples, TimeSurface surface, boolean includeIsochrones){
+    public ResultSet(SampleSet samples, TimeSurface surface, boolean includeHistograms, boolean includeIsochrones){
         id = samples.pset.id + "_" + surface.id;
 
         PointSet targets = samples.pset;
@@ -72,7 +67,8 @@ public class ResultSet implements Serializable{
 
         this.cutoffMinutes = surface.cutoffMinutes;
 
-        buildHistograms(times, targets);
+        if (includeHistograms)
+            buildHistograms(times, targets);
 
         this.times = times;
         
@@ -201,17 +197,21 @@ public class ResultSet implements Serializable{
                     jgen.writeEndObject();
                 }
 
-                jgen.writeObjectFieldStart("data"); {
-                    for(String propertyId : histograms.keySet()) {
+                if (histograms != null) {
+                    jgen.writeObjectFieldStart("data");
+                    {
+                        for (String propertyId : histograms.keySet()) {
 
-                        jgen.writeObjectFieldStart(propertyId); {
-                            histograms.get(propertyId).writeJson(jgen);
+                            jgen.writeObjectFieldStart(propertyId);
+                            {
+                                histograms.get(propertyId).writeJson(jgen);
+                            }
+                            jgen.writeEndObject();
+
                         }
-                        jgen.writeEndObject();
-
                     }
+                    jgen.writeEndObject();
                 }
-                jgen.writeEndObject();
             }
             jgen.writeEndObject();
 

--- a/src/main/java/org/opentripplanner/api/resource/SurfaceResource.java
+++ b/src/main/java/org/opentripplanner/api/resource/SurfaceResource.java
@@ -117,7 +117,8 @@ public class SurfaceResource extends RoutingResource {
     public Response getIndicator (@PathParam("surfaceId") Integer surfaceId,
                                   @QueryParam("targets")  String  targetPointSetId,
                                   @QueryParam("origins")  String  originPointSetId,
-                                  @QueryParam("detail")   boolean detail) {
+                                  @QueryParam("includeHistograms")   boolean histograms,
+                                  @QueryParam("includeIsochrones")   boolean isochrones) {
 
         final TimeSurface surf = otpServer.surfaceCache.get(surfaceId);
         if (surf == null) return badRequest("Invalid TimeSurface ID.");
@@ -125,14 +126,9 @@ public class SurfaceResource extends RoutingResource {
         if (pset == null) return badRequest("Missing or invalid target PointSet ID.");
 
         Router router = otpServer.getRouter(surf.routerId);
-
         SampleSet samples = pset.getOrCreateSampleSet(router.graph);
-
-        final ResultSet indicator = new ResultSet(samples, surf, detail);
-        if (indicator == null) return badServer("Could not compute indicator as requested.");
-
+        final ResultSet indicator = new ResultSet(samples, surf, histograms, isochrones);
         return Response.ok().entity((StreamingOutput) output -> indicator.writeJson(output, pset)).build();
-
     }
 
     /** Create vector isochrones for a surface. */


### PR DESCRIPTION
Make getting histograms (binned values) optional when requesting indicators.

Useful for when only the id -> travel time map is needed, such as when indicator value based bins aren't meaningful (only care if point is accessible or not).
